### PR TITLE
docs: update README unsupported notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # vertexai-google
+Product is not SUpported anymore
 
 [![CI Build](https://github.com/axonivy-market/vertexai-google/actions/workflows/ci.yml/badge.svg)](https://github.com/axonivy-market/vertexai-google/actions/workflows/ci.yml)
 


### PR DESCRIPTION
Adds `Product is not SUpported anymore` right below the first heading in root README.md.